### PR TITLE
FIX: The CACHE_DRIVER constant defaults to 'memory' if undefined (Kanboard version >= 1.2.47)

### DIFF
--- a/Template/config_sections/app-sections.php
+++ b/Template/config_sections/app-sections.php
@@ -215,7 +215,7 @@
             <?php else: ?>
                 <span class="pass-tick" title="<?= t('This directory is writeable by the web server user') ?>">&#10004;</span>
             <?php endif ?>
-            <?php if (CACHE_DRIVER == 'memory'): ?>
+            <?php if (!defined('CACHE_DRIVER') or (CACHE_DRIVER == 'memory')): ?>
                 <span class="p-note"><i><?= e('%s as Cache Driver is set to %s', '<strong>' . t('Not required') . '</strong>', '<code>memory</code>') ?></i></span>
             <?php else: ?>
                 <?php if ($this->user->isAdmin()): ?>


### PR DESCRIPTION
The 'file' implementation of the cache was removed in Kanboard version 1.2.47 along with the CACHE_DRIVER constant:
- https://github.com/kanboard/kanboard/blob/v1.2.47/config.default.php
- https://github.com/kanboard/kanboard/commit/bcbaa05684cf20f262da894365c0b7fad913da8c

Using Kanboard version >= 1.2.47 causes the Configuration page to crash unless this case is handled.